### PR TITLE
Ensure each model has a database table before attempting to truncate.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    factory_girl-preload (2.3.1)
+    factory_girl-preload (2.3.2)
       activerecord
       factory_girl (>= 4.0)
 
@@ -40,7 +40,7 @@ GEM
     coderay (1.1.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    factory_girl (4.4.0)
+    factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     hike (1.2.3)
     i18n (0.6.11)

--- a/lib/factory_girl/preload.rb
+++ b/lib/factory_girl/preload.rb
@@ -50,11 +50,15 @@ module FactoryGirl
         else raise "Couldn't find #{clean_with} clean type"
       end
 
-      names = active_record.descendants.collect(&:table_name).uniq if names.empty?
+      names = active_record.descendants.select(&:table_exists?).collect(&:table_name).uniq if names.empty?
 
       connection.disable_referential_integrity do
         names.each do |table|
-          connection.execute(query % connection.quote_table_name(table))
+          begin
+            connection.execute(query % connection.quote_table_name(table))
+          rescue ActiveRecord::StatementInvalid
+            next
+          end
         end
       end
     end

--- a/lib/factory_girl/preload/version.rb
+++ b/lib/factory_girl/preload/version.rb
@@ -3,7 +3,7 @@ module FactoryGirl
     module Version
       MAJOR = 2
       MINOR = 3
-      PATCH = 1
+      PATCH = 2
       STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
     end
   end


### PR DESCRIPTION
Cherry picks commit on factory_girl-preload to deal with models that don't have tables backing them.