### PR TITLE
Reject ActiveRecord descendants in blank

### DIFF
--- a/lib/factory_girl/preload.rb
+++ b/lib/factory_girl/preload.rb
@@ -50,7 +50,7 @@ module FactoryGirl
         else raise "Couldn't find #{clean_with} clean type"
       end
 
-      names = active_record.descendants.collect(&:table_name).uniq if names.empty?
+      names = active_record.descendants.collect(&:table_name).reject(&:blank?).uniq if names.empty?
 
       connection.disable_referential_integrity do
         names.each do |table|


### PR DESCRIPTION
Fix array when there is descendant in ActiveRecord null or empty string:

```ruby
Loading development environment (Rails 4.2.4)
2.2.2 :001 > ActiveRecord::Base.descendants.collect(&:table_name).uniq
=> ["sessions", "wice_grid_serialized_queries", "users", "movies", nil, "content_warnings_movies", "movie_translations"]
```

```ruby
Loading development environment (Rails 4.2.4)
2.2.2 :001 > ActiveRecord::Base.descendants.collect(&:table_name).reject(&:blank?).uniq
=> ["sessions", "wice_grid_serialized_queries", "users", "movies", "content_warnings_movies", "movie_translations"]
```

Rails 4.2.4
factory_girl-preload 2.3.1