### PR TITLE
Remove binding pry on after initialize

### DIFF
--- a/lib/factory_girl/preload/engine.rb
+++ b/lib/factory_girl/preload/engine.rb
@@ -4,7 +4,6 @@ module FactoryGirl
   module Preload
     class Engine < Rails::Engine
       ActiveSupport.on_load(:after_initialize, yield: true) do
-        require "pry"; binding.pry
         ::FactoryGirl::SyntaxRunner.send(:include, Helpers)
       end
 


### PR DESCRIPTION
Hi @fnando,

While I was reading the gem's code, I had found the ```binding.pry``` left in the code.